### PR TITLE
fix

### DIFF
--- a/openapi_client/api/metrics_api.py
+++ b/openapi_client/api/metrics_api.py
@@ -494,7 +494,7 @@ class MetricsApi(object):
         _auth_settings = ['Klaviyo-API-Key', 'OAuth']  # noqa: E501
 
         _response_types_map = {
-            '201': "Dict[str, object]",
+            '200': "Dict[str, object]",
             '4XX': "GetAccounts4XXResponse",
             '5XX': "GetAccounts4XXResponse",
         }


### PR DESCRIPTION
in 2023-08-15 metrics aggregate returns **200** status not 201 as shown [at the documentation](https://developers.klaviyo.com/en/reference/query_metric_aggregates)

My request:
```
POST https://a.klaviyo.com/api/metric-aggregates/
Authorization: Klaviyo-API-Key ********
accept: application/json
revision: 2023-08-15
Content-Type: application/json
Content-Length: 375
Connection: Keep-Alive
User-Agent: Apache-HttpClient/4.5.14 (Java/17.0.6)
Accept-Encoding: br,deflate,gzip,x-gzip

{
  "data": {
    "type": "metric-aggregate",
    "attributes": {
      "metric_id": "XFxjxt",
      "measurements": [
        "count"
      ],
      "filter": [
        "greater-or-equal(datetime,2022-12-30T22:00:00+00:00)",
        "less-than(datetime,2023-09-09T21:00:00+00:00)"
      ],
      "interval": "day",
      "page_size": 500,
      "timezone": "UTC"
    }
  }
}
```
part of response:
```
HTTP/1.1 200 OK
Date: Sun, 10 Sep 2023 10:37:41 GMT
...
{
  "data": {
    "type": "metric-aggregate",
    "id": "4290621170589644056",
    "attributes": {
      "dates": [
        "2022-12-30T00:00:00+00:00",
        "2022-12-31T00:00:00+00:00",
...
```
![image](https://github.com/klaviyo/klaviyo-api-python/assets/5002775/0111263e-c299-4200-a970-2eec9c29d7ba)

tested on multiple versions including:
- v2023-02-22
- v2023-01-24
- v2022-10-17
![image](https://github.com/klaviyo/klaviyo-api-python/assets/5002775/b960a28d-0d90-44a7-8774-de1b60c10f9e)
